### PR TITLE
refactor: use simpler s3 repo configuration

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -6874,11 +6874,11 @@
 			}
 		},
 		"datastore-s3": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/datastore-s3/-/datastore-s3-0.2.1.tgz",
-			"integrity": "sha512-X4j0CszaRoxzR0uG6CRkrB1JW197tgTngasiHBjUGW6PXHjtcY4v9hkyGPBiESBIlN7u0xOXWaQXpruPK++U3Q==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/datastore-s3/-/datastore-s3-0.2.3.tgz",
+			"integrity": "sha512-FlNzwgrAAIYAWRVrVTAQdrDH5PfhGTOcmYCLk9JVEMGtbwrfbttG05Oefy58IYXClujAnbVmF2LUDuC0P3BoDQ==",
 			"requires": {
-				"async": "^2.6.1",
+				"async": "^2.6.2",
 				"datastore-core": "~0.6.0",
 				"interface-datastore": "~0.6.0",
 				"once": "^1.4.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,9 +18,9 @@
   },
   "homepage": "https://github.com/ipfs-shipyard/ipfs-npm-registry-mirror#readme",
   "dependencies": {
-    "aws-sdk": "^2.325.0",
+    "aws-sdk": "^2.402.0",
     "cids": "~0.5.5",
-    "datastore-s3": "~0.2.0",
+    "datastore-s3": "~0.2.3",
     "debug": "^4.0.1",
     "express": "^4.16.3",
     "express-prom-bundle": "^5.0.2",


### PR DESCRIPTION
Uses the new `createRepo` utility function in `datastore-s3` to create the repo.